### PR TITLE
Fix: add missing token method to typescript declaration

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -14,6 +14,7 @@ declare module '@preprio/nodejs-sdk' {
       userId: string = null,
     }: ClientOptions);
 
+    public token(token: string): this;
     public userId(userId: string): this;
     public timeout(milliseconds: number): this;
     public query(query: Record<string, any>): this;


### PR DESCRIPTION
Instance method token was public in javascript, but not added as a public method in the typescript declaration. Added token method to typescript declaration file.

This fixes the error as seen in the screenshot below.

<img width="644" alt="image" src="https://github.com/user-attachments/assets/e2223bea-3c8e-4c56-90c7-0815c0656fc4">